### PR TITLE
add a terraform variable 'aws_src_dest_check' to disable EC2 src/dest…

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -80,6 +80,7 @@ resource "aws_instance" "k8s-master" {
   count = var.aws_kube_master_num
 
   availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  source_dest_check     = var.aws_src_dest_check
   subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
   vpc_security_group_ids = module.aws-vpc.aws_security_group
@@ -107,6 +108,7 @@ resource "aws_instance" "k8s-etcd" {
   count = var.aws_etcd_num
 
   availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  source_dest_check     = var.aws_src_dest_check
   subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
   vpc_security_group_ids = module.aws-vpc.aws_security_group
@@ -127,6 +129,7 @@ resource "aws_instance" "k8s-worker" {
   count = var.aws_kube_worker_num
 
   availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
+  source_dest_check     = var.aws_src_dest_check
   subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
   vpc_security_group_ids = module.aws-vpc.aws_security_group

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -21,6 +21,9 @@ aws_etcd_size = "t2.medium"
 aws_kube_worker_num  = 4
 aws_kube_worker_size = "t2.medium"
 
+#EC2 Source/Dest Check
+aws_src_dest_check      = true
+
 #Settings AWS ELB
 
 aws_elb_api_port                = 6443

--- a/contrib/terraform/aws/terraform.tfvars.example
+++ b/contrib/terraform/aws/terraform.tfvars.example
@@ -25,6 +25,9 @@ aws_kube_worker_size = "t2.medium"
 
 aws_cluster_ami = "ami-903df7ff"
 
+#EC2 Source/Dest Check
+aws_src_dest_check      = true
+
 #Settings AWS ELB
 
 aws_elb_api_port = 6443

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -88,6 +88,16 @@ variable "aws_kube_worker_size" {
 }
 
 /*
+* EC2 Source/Dest Check
+*
+*/
+variable "aws_src_dest_check" {
+  description   = "Instance source/destination check of Kubernetes Cluster"
+  type          = bool
+  default	= true
+}
+
+/*
 * AWS ELB Settings
 *
 */


### PR DESCRIPTION
- EC2 source/destination check를 활성화/비활성화하는 테라폼 입력 변수('aws_src_dest_check') 추가
- k8s 클러스터에만 적용되며, bastion 인스턴스에는 적용되지 않음
- boolean 타입(true / false)이며, 변수를 정의하지 않을 경우 true 값이 기본 적용됨