### PR TITLE
extends timeout for VM bootup

### DIFF
--- a/.github/workflows/external-ci.yml
+++ b/.github/workflows/external-ci.yml
@@ -34,12 +34,12 @@ jobs:
           rm -f e2e_sshkey* && ssh-keygen -b 2048 -t rsa -f ./e2e_sshkey -q -N ""
           chmod 600 e2e_sshkey && chmod 600 e2e_sshkey.pub
           terraform apply -auto-approve
-          for ((i=0; i<=18; i++))
+          for ((i=0; i<=30; i++))
           do
             ${{ steps.vars.outputs.SSH_MASTER }} "echo 2>&1" && break || echo "Waits master VM to be up"
             sleep 10
           done
-          for ((i=0; i<=18; i++))
+          for ((i=0; i<=30; i++))
           do
             ${{ steps.vars.outputs.SSH_WORKER }} "echo 2>&1" && break || echo "Waits worker VM to be up"
             sleep 10


### PR DESCRIPTION
- VM들의 ssh connectivity를 test하는 시간을 3분에서 5분으로 연장하여 VM 부팅으로 인한 CI test 실패 문제 완화