### PR TITLE
[ims][274854] serviceAccount 자체 생성

### DIFF
--- a/roles/kubernetes-apps/hypercloud/templates/hypercloud-single-operator-v5.0.25.3.yaml.j2
+++ b/roles/kubernetes-apps/hypercloud/templates/hypercloud-single-operator-v5.0.25.3.yaml.j2
@@ -443,6 +443,12 @@ rules:
   verbs:
   - get
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hypercloud-single-operator-service-account
+  namespace: hypercloud5-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -454,7 +460,7 @@ roleRef:
   name: hypercloud-single-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: hypercloud-single-operator-service-account
   namespace: hypercloud5-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -467,7 +473,7 @@ roleRef:
   name: hypercloud-single-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: hypercloud-single-operator-service-account
   namespace: hypercloud5-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -480,7 +486,7 @@ roleRef:
   name: hypercloud-single-operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: hypercloud-single-operator-service-account
   namespace: hypercloud5-system
 ---
 apiVersion: v1
@@ -570,6 +576,7 @@ spec:
             cpu: 100m
             memory: 20Mi
       dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: hypercloud-single-operator-service-account
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule

--- a/roles/kubernetes-apps/hypercloud/templates/hypercloud-single-operator-v5.0.25.9.yaml.j2
+++ b/roles/kubernetes-apps/hypercloud/templates/hypercloud-single-operator-v5.0.25.9.yaml.j2
@@ -428,6 +428,12 @@ rules:
   verbs:
   - get
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hypercloud-single-operator-service-account
+  namespace: hypercloud5-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -439,7 +445,7 @@ roleRef:
   name: hypercloud-single-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: hypercloud-single-operator-service-account
   namespace: hypercloud5-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -452,7 +458,7 @@ roleRef:
   name: hypercloud-single-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: hypercloud-single-operator-service-account
   namespace: hypercloud5-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -465,7 +471,7 @@ roleRef:
   name: hypercloud-single-operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: hypercloud-single-operator-service-account
   namespace: hypercloud5-system
 ---
 apiVersion: v1
@@ -555,6 +561,7 @@ spec:
             cpu: 100m
             memory: 20Mi
       dnsPolicy: ClusterFirstWithHostNet
+      serviceAccount: hypercloud-single-operator-service-account
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
[[ims][274854]](https://ims.tmaxsoft.com/tody/ims/issue/issueView.do?issueId=274854&menuCode=issue_search)

hypercloud-single-operator에서 default 서비스 어카운트를 사용하지 않고, 새롭게 만들어서 사용하도록 수정