### PR TITLE
Add role to deploy External CoreDNS

### DIFF
--- a/docs/tmaxcloud/nodelocaldns_custom_domain.md
+++ b/docs/tmaxcloud/nodelocaldns_custom_domain.md
@@ -54,6 +54,18 @@ wildcard 도메인은 `*.my.domain  IN   A 1.2.3.4` 형식이라서 'my.domain' 
   ```
   사용 예시:  `{{호스트}}.hypercloud.shinhan.com` DNS query할 때 응답은 10.12.10.12 
 
+## External CoreDNS - k8s_gatway
+Kubernetes external resources (LoadBalancer Service, Ingress) 외부에서 도메인으로 접속 할 수 있게 해 주는 기능입니다.
+* External CoreDNS 사용을 휘한 설정입니다.
+  파일: `inventory/tmaxcloud/group_vars/k8s_cluster/k8s-cluster.yml`
+  ```yaml
+  enable_excoredns: true
+  excoredns_zone: "hypercloud.shinhan.com"
+  ```
+  `true` : External CoreDNS 사용, `false` External CoreDNS 미사용  
+  `excoredns_zone`: 사용하고 싶은 도메인 이름 (ex: hypercloud.shinhan.com)  
+  Service 사용 예시: {{ ServiceName }}.{{ ServiceNamespace }}.hypercloud.shinhan.com  
+  Ingress 사용 예시: ingress의 FQDN hostname - spec.rules[].host  
 
 ## Static POD `kube-apiserver` 에 'clusterFirstWithHostNet' dnsPolicy 적용
 기본적으로 kube-apiserver POD는 hostNetwork를 사용해서 cluster 네트워크랑 통신 안돼서 cluster domain 접속 안됩니다.  

--- a/inventory/tmaxcloud/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/tmaxcloud/group_vars/k8s_cluster/k8s-cluster.yml
@@ -187,7 +187,11 @@ enable_custom_domain: true
 custom_domain_name: "hypercloud.shinhan.com"
 custom_domain_ip: 10.12.10.12
 api_server_dns_cfwhn: true
-#
+
+# Enable external coredns - k8s_gateway
+enable_excoredns: true
+excoredns_zone: "hypercloud.shinhan.com"
+excoredns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(53)|ipaddr('address') }}"
 
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: none

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -517,6 +517,9 @@ coredns_version: "v1.7.0"
 coredns_image_repo: "{{ kube_image_repo }}{{'/coredns/coredns' if (coredns_image_is_namespaced | bool) else '/coredns' }}"
 coredns_image_tag: "{{ coredns_version if (coredns_image_is_namespaced | bool) else (coredns_version | regex_replace('^v', '')) }}"
 
+excoredns_image_repo: "{{ quay_image_repo }}/oriedge/k8s_gateway"
+excoredns_image_tag: "v0.1.8"
+
 nodelocaldns_version: "1.17.1"
 nodelocaldns_image_repo: "{{ kube_image_repo }}/dns/k8s-dns-node-cache"
 nodelocaldns_image_tag: "{{ nodelocaldns_version }}"

--- a/roles/kubernetes-apps/ansible/tasks/excoredns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/excoredns.yml
@@ -1,0 +1,43 @@
+---
+- name: Kubernetes Apps | Lay Down External CoreDNS templates
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
+  loop:
+    - { name: excoredns, file: excoredns-clusterrole.yml, type: clusterrole }
+    - { name: excoredns, file: excoredns-clusterrolebinding.yml, type: clusterrolebinding }
+    - { name: excoredns, file: excoredns-config.yml, type: configmap }
+    - { name: excoredns, file: excoredns-deployment.yml, type: deployment }
+    - { name: excoredns, file: excoredns-sa.yml, type: sa }
+    - { name: excoredns, file: excoredns-svc.yml, type: svc }
+  register: excoredns_manifests
+  vars:
+    clusterIP: "{{ excoredns_server }}"
+  when:
+    - dns_mode in ['coredns', 'coredns_dual']
+    - inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - excoredns
+
+- name: Kubernetes Apps | Start External CoreDNS Resources
+  kube:
+    name: "{{ item.item.name }}"
+    namespace: "kube-system"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
+    state: "latest"
+  with_items:
+    - "{{ excoredns_manifests.results | default({}) }}"
+  when:
+    - dns_mode != 'none'
+    - inventory_hostname == groups['kube_control_plane'][0]
+    - not item is skipped
+  register: resource_result
+  until: resource_result is succeeded
+  retries: 4
+  delay: 5
+  tags:
+    - excoredns
+  loop_control:
+    label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -28,6 +28,15 @@
   tags:
     - coredns
 
+- name: Kubernetes Apps | External CoreDNS
+  import_tasks: "excoredns.yml"
+  when:
+    - enable_excoredns
+    - dns_mode in ['coredns', 'coredns_dual']
+    - inventory_hostname == groups['kube_control_plane'][0]
+  tags:
+    - excoredns
+
 - name: Kubernetes Apps | nodelocalDNS
   import_tasks: "nodelocaldns.yml"
   when:

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -70,3 +70,19 @@ data:
   hosts: |
     {{ dns_etchosts | indent(width=4, indentfirst=None) }}
 {% endif %}
+{% if enable_excoredns %}
+    {{ excoredns_zone }}:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        forward . {{ excoredns_server }} {
+          prefer_udp
+        }
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+{% endif %}

--- a/roles/kubernetes-apps/ansible/templates/excoredns-clusterrole.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/excoredns-clusterrole.yml.j2
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: excoredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - watch

--- a/roles/kubernetes-apps/ansible/templates/excoredns-clusterrolebinding.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/excoredns-clusterrolebinding.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: excoredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: excoredns
+subjects:
+- kind: ServiceAccount
+  name: excoredns
+  namespace: kube-system

--- a/roles/kubernetes-apps/ansible/templates/excoredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/excoredns-config.yml.j2
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: excoredns
+  namespace: kube-system
+data:
+  Corefile: |-
+    {{ excoredns_zone }}:53 {
+        errors
+        ready
+        k8s_gateway {{ excoredns_zone }}
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+---

--- a/roles/kubernetes-apps/ansible/templates/excoredns-deployment.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/excoredns-deployment.yml.j2
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: excoredns
+  namespace: kube-system
+  labels:
+    k8s-app: "excoredns"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "excoredns"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      k8s-app: "excoredns"
+  template:
+    metadata:
+      labels:
+        k8s-app: "excoredns"
+      annotations:
+        createdby: 'kubespray'
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: excoredns
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                k8s-app: excoredns
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - ""
+      containers:
+      - name: "excoredns"
+        image: "{{ excoredns_image_repo }}:{{ excoredns_image_tag }}"
+        imagePullPolicy: {{ k8s_image_pull_policy }}
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        resources:
+          limits:
+            memory: {{ dns_memory_limit }}
+          requests:
+            cpu: {{ dns_cpu_requests }}
+            memory: {{ dns_memory_requests }}
+        ports:
+        - {containerPort: 53, protocol: UDP, name: udp-53}
+        - {containerPort: 53, protocol: TCP, name: tcp-53}
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: excoredns
+            items:
+            - key: Corefile
+              path: Corefile

--- a/roles/kubernetes-apps/ansible/templates/excoredns-sa.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/excoredns-sa.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: excoredns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+---

--- a/roles/kubernetes-apps/ansible/templates/excoredns-svc.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/excoredns-svc.yml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: excoredns
+  namespace: kube-system
+  labels:
+    k8s-app: excoredns
+    kubernetes.io/name: "excoredns"
+    addonmanager.kubernetes.io/mode: Reconcile
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+  selector:
+    k8s-app: "excoredns"
+  clusterIP: {{ clusterIP }}
+  ports:
+  - {port: 53, protocol: UDP, name: udp-53}
+  type: LoadBalancer
+---

--- a/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/nodelocaldns-config.yml.j2
@@ -69,6 +69,18 @@ data:
         }
         prometheus :9253
     }
+{% if enable_excoredns %}
+    {{ excoredns_zone }}:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind {{ nodelocaldns_ip }}
+        forward . {{ excoredns_server }} {
+          prefer_udp
+        }
+    }
+{% endif %}
     .:53 {
         errors
         cache 30


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
Enable External CoreDNS - Kubernetes external resources (LoadBalancer Service, Ingress) 
외부에서 도메인으로 접속 할 수 있게 해 주는 기능입니다.

**What this PR does / why we need it**:
- Deploy External CoreDNS Deployment and LoadBalancer Service.
- Enable External domain
- Enable to publicly access Kubernetes Ingress and LoadBalancer service 

**Which issue(s) this PR fixes**:
Fix ability to access to Service or Ingress FQDN from Client PC browser
Fix kube-apiserver POD setting - hyperauth url NOT resolvable

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
