### PR TITLE
deletes cert-manager namespace only if it exists

### DIFF
--- a/.github/workflows/external-ci.yml
+++ b/.github/workflows/external-ci.yml
@@ -83,11 +83,11 @@ jobs:
         run: |
           FATAL_LOG=`${{ steps.vars.outputs.SSH_MASTER }} "cat /root/kubespray/output.log | grep fatal"`
           if [ ! -z "${FATAL_LOG}" ]; then
-            echo ${FATAL_LOG};
+            echo "${FATAL_LOG}";
           fi 
           FAIL_LOG=`${{ steps.vars.outputs.SSH_MASTER }} "cat /root/kubespray/output.log | grep failed"`
           if [ ! -z "${FAIL_LOG}" ]; then
-            echo ${FAIL_LOG};
+            echo "${FAIL_LOG}";
           fi 
           cd ${{ steps.vars.outputs.TERRAFORM_DIR }}
           terraform destroy -auto-approve

--- a/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
+++ b/roles/kubernetes-apps/ansible/tasks/cleanup_dns.yml
@@ -4,6 +4,7 @@
   register: createdby_annotation
   changed_when: false
   ignore_errors: true
+  failed_when: false
   when:
     - dns_mode in ['coredns', 'coredns_dual']
     - inventory_hostname == groups['kube_control_plane'][0]

--- a/roles/kubernetes-apps/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/cert_manager/tasks/main.yml
@@ -11,8 +11,7 @@
 
 - name: Cert Manager | Remove legacy namespace
   shell: |
-    {{ bin_dir }}/kubectl delete namespace {{ cert_manager_namespace }}
-  ignore_errors: true  # noqa ignore-errors
+    {{ bin_dir }}/kubectl get namespace {{ cert_manager_namespace }} &>/dev/null; if [ $? -eq 0 ]; then {{ bin_dir }}/kubectl delete namespace {{ cert_manager_namespace }}; fi
   when:
     - inventory_hostname == groups['kube_control_plane'][0]
   tags:


### PR DESCRIPTION
- cert-manager namespace가 존재할 때만 delete 명령을 수행하도록 수정하여 불필요한 error log 출력하는 것을 지움
- coredns가 존재하지 않을 때 get을 하는 경우 stderr를 무시하도록 설정