### PR TITLE
Terraform AWS ELB/NLB setting

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -33,6 +33,7 @@ module "aws-elb" {
   aws_vpc_id            = module.aws-vpc.aws_vpc_id
   aws_avail_zones       = slice(data.aws_availability_zones.available.names, 0, 2)
   aws_subnet_ids_public = module.aws-vpc.aws_subnet_ids_public
+  aws_elb_api_internal  = var.aws_elb_api_internal
   aws_elb_api_port      = var.aws_elb_api_port
   k8s_secure_api_port   = var.k8s_secure_api_port
   default_tags          = var.default_tags
@@ -52,7 +53,7 @@ module "aws-iam" {
 resource "aws_instance" "bastion-server" {
   ami                         = data.aws_ami.distro.id
   instance_type               = var.aws_bastion_size
-  count                       = length(var.aws_cidr_subnets_public)
+  count                       = var.aws_bastion_num
   associate_public_ip_address = true
   availability_zone           = element(slice(data.aws_availability_zones.available.names, 0, 2), count.index)
   subnet_id                   = element(module.aws-vpc.aws_subnet_ids_public, count.index)

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -39,6 +39,19 @@ module "aws-elb" {
   default_tags          = var.default_tags
 }
 
+module "aws-nlb" {
+  source = "./modules/nlb"
+
+  aws_cluster_name      = var.aws_cluster_name
+  aws_vpc_id            = module.aws-vpc.aws_vpc_id
+  aws_avail_zones       = slice(data.aws_availability_zones.available.names, 0, 2)
+  aws_subnet_ids_public = module.aws-vpc.aws_subnet_ids_public
+  aws_elb_api_internal  = var.aws_elb_api_internal
+  aws_elb_api_port      = var.aws_elb_api_port
+  k8s_secure_api_port   = var.k8s_secure_api_port
+  default_tags          = var.default_tags
+}
+
 module "aws-iam" {
   source = "./modules/iam"
 
@@ -102,6 +115,12 @@ resource "aws_elb_attachment" "attach_master_nodes" {
   instance = element(aws_instance.k8s-master.*.id, count.index)
 }
 
+resource "aws_lb_target_group_attachment" "tg-attach_master_nodes" {
+  count    = var.aws_kube_master_num
+  target_group_arn = module.aws-nlb.aws_nlb_api_tg_arn
+  target_id = element(aws_instance.k8s-master.*.id, count.index)
+}
+
 resource "aws_instance" "k8s-etcd" {
   ami           = data.aws_ami.distro.id
   instance_type = var.aws_etcd_size
@@ -161,6 +180,7 @@ data "template_file" "inventory" {
     list_node                 = join("\n", aws_instance.k8s-worker.*.private_dns)
     list_etcd                 = join("\n", aws_instance.k8s-etcd.*.private_dns)
     elb_api_fqdn              = "apiserver_loadbalancer_domain_name=\"${module.aws-elb.aws_elb_api_fqdn}\""
+    nlb_api_fqdn              = "apiserver_loadbalancer_domain_name=\"${module.aws-nlb.aws_nlb_api_fqdn}\""
   }
 }
 

--- a/contrib/terraform/aws/modules/elb/main.tf
+++ b/contrib/terraform/aws/modules/elb/main.tf
@@ -46,6 +46,7 @@ resource "aws_elb" "aws-elb-api" {
     interval            = 30
   }
 
+  internal                    = var.aws_elb_api_internal
   cross_zone_load_balancing   = true
   idle_timeout                = 400
   connection_draining         = true

--- a/contrib/terraform/aws/modules/elb/variables.tf
+++ b/contrib/terraform/aws/modules/elb/variables.tf
@@ -28,3 +28,9 @@ variable "default_tags" {
   description = "Tags for all resources"
   type        = map(string)
 }
+
+variable "aws_elb_api_internal" {
+  description   = "AWS ELB Scheme Internet-facing/Internal"
+  type          = bool
+  default	= true
+}

--- a/contrib/terraform/aws/modules/nlb/main.tf
+++ b/contrib/terraform/aws/modules/nlb/main.tf
@@ -1,0 +1,41 @@
+# Create a new AWS NLB for K8S API
+resource "aws_lb" "aws-nlb-api" {
+  name               = "kubernetes-nlb-${var.aws_cluster_name}"
+  load_balancer_type = "network"
+  internal           = var.aws_elb_api_internal
+  subnets            = var.aws_subnet_ids_public
+  idle_timeout       = 400
+  enable_cross_zone_load_balancing   = true
+
+  tags = merge(var.default_tags, tomap({
+    Name = "kubernetes-${var.aws_cluster_name}-nlb-api"
+  }))
+}
+
+# Create a new AWS NLB Instance Target Group
+resource "aws_lb_target_group" "aws-nlb-api-tg" {
+  name     = "kubernetes-nlb-tg-${var.aws_cluster_name}"
+  port     = var.k8s_secure_api_port
+  protocol = "TCP"
+  vpc_id   = var.aws_vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+    protocol            = "HTTPS"
+    path                = "/healthz"
+  }
+}
+
+# Create a new AWS NLB Listener listen to target group
+resource "aws_lb_listener" "aws-nlb-api-listener" {
+  load_balancer_arn = aws_lb.aws-nlb-api.arn
+  port              = var.aws_elb_api_port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.aws-nlb-api-tg.arn
+  }
+}

--- a/contrib/terraform/aws/modules/nlb/outputs.tf
+++ b/contrib/terraform/aws/modules/nlb/outputs.tf
@@ -1,0 +1,11 @@
+output "aws_nlb_api_id" {
+  value = aws_lb.aws-nlb-api.id
+}
+
+output "aws_nlb_api_fqdn" {
+  value = aws_lb.aws-nlb-api.dns_name
+}
+
+output "aws_nlb_api_tg_arn" {
+  value = aws_lb_target_group.aws-nlb-api-tg.arn
+}

--- a/contrib/terraform/aws/modules/nlb/variables.tf
+++ b/contrib/terraform/aws/modules/nlb/variables.tf
@@ -1,0 +1,36 @@
+variable "aws_cluster_name" {
+  description = "Name of Cluster"
+}
+
+variable "aws_vpc_id" {
+  description = "AWS VPC ID"
+}
+
+variable "aws_elb_api_port" {
+  description = "Port for AWS ELB"
+}
+
+variable "k8s_secure_api_port" {
+  description = "Secure Port of K8S API Server"
+}
+
+variable "aws_avail_zones" {
+  description = "Availability Zones Used"
+  type        = list(string)
+}
+
+variable "aws_subnet_ids_public" {
+  description = "IDs of Public Subnets"
+  type        = list(string)
+}
+
+variable "default_tags" {
+  description = "Tags for all resources"
+  type        = map(string)
+}
+
+variable "aws_elb_api_internal" {
+  description   = "AWS ELB Scheme Internet-facing/Internal"
+  type          = bool
+  default	= true
+}

--- a/contrib/terraform/aws/output.tf
+++ b/contrib/terraform/aws/output.tf
@@ -18,6 +18,10 @@ output "aws_elb_api_fqdn" {
   value = "${module.aws-elb.aws_elb_api_fqdn}:${var.aws_elb_api_port}"
 }
 
+output "aws_nlb_api_fqdn" {
+  value = "${module.aws-nlb.aws_nlb_api_fqdn}:${var.aws_elb_api_port}"
+}
+
 output "inventory" {
   value = data.template_file.inventory.rendered
 }

--- a/contrib/terraform/aws/sample-inventory/cluster.tfvars
+++ b/contrib/terraform/aws/sample-inventory/cluster.tfvars
@@ -26,6 +26,7 @@ aws_kube_worker_num = 4
 aws_kube_worker_size = "t2.medium"
 
 #Settings AWS ELB
+aws_elb_api_internal = false
 
 aws_elb_api_port = 6443
 

--- a/contrib/terraform/aws/sample-inventory/group_vars
+++ b/contrib/terraform/aws/sample-inventory/group_vars
@@ -1,1 +1,1 @@
-../../../../inventory/sample/group_vars
+../../../../inventory/tmaxcloud/group_vars/

--- a/contrib/terraform/aws/templates/inventory.tpl
+++ b/contrib/terraform/aws/templates/inventory.tpl
@@ -25,4 +25,4 @@ kube_control_plane
 
 
 [k8s_cluster:vars]
-${elb_api_fqdn}
+${nlb_api_fqdn}

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -25,7 +25,7 @@ data "aws_ami" "distro" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    values = ["CentOS 8.4.2105 x86_64"]
   }
 
   filter {
@@ -33,7 +33,7 @@ data "aws_ami" "distro" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["125523088429"] # Canonical
 }
 
 //AWS VPC Variables
@@ -58,6 +58,10 @@ variable "aws_bastion_size" {
   description = "EC2 Instance Size of Bastion Host"
 }
 
+variable "aws_bastion_num" {
+  description = "Number of Bastion Nodes"
+}
+
 /*
 * AWS EC2 Settings
 * The number should be divisable by the number of used
@@ -71,6 +75,10 @@ variable "aws_kube_master_size" {
   description = "Instance size of Kube Master Nodes"
 }
 
+variable "aws_kube_master_disk_size" {
+  description = "Disk size for Kubernetes Master Nodes (in GiB)"
+}
+
 variable "aws_etcd_num" {
   description = "Number of etcd Nodes"
 }
@@ -79,12 +87,20 @@ variable "aws_etcd_size" {
   description = "Instance size of etcd Nodes"
 }
 
+variable "aws_etcd_disk_size" {
+  description = "Disk size for etcd Nodes (in GiB)"
+}
+
 variable "aws_kube_worker_num" {
   description = "Number of Kubernetes Worker Nodes"
 }
 
 variable "aws_kube_worker_size" {
   description = "Instance size of Kubernetes Worker Nodes"
+}
+
+variable "aws_kube_worker_disk_size" {
+  description = "Disk size for Kubernetes Worker Nodes (in GiB)"
 }
 
 /*
@@ -116,4 +132,10 @@ variable "default_tags" {
 
 variable "inventory_file" {
   description = "Where to store the generated inventory file"
+}
+
+variable "aws_elb_api_internal" {
+  description   = "AWS ELB Scheme Internet-facing/Internal"
+  type          = bool
+  default	= true
 }

--- a/docs/tmaxcloud/terraform_aws_elb.md
+++ b/docs/tmaxcloud/terraform_aws_elb.md
@@ -1,0 +1,8 @@
+# Terraform's AWS ELB setting
+- Create Kube API ELB type as public or private  
+  file: contrib/terraform/aws/terraform.tfvars  
+  ```
+  aws_elb_api_internal = false
+  ```
+  `false` : Public  
+  `true`  : Private  


### PR DESCRIPTION
**What type of PR is this?**
- Fix unable to create AWS ELB as private IP
- Add new module

**What this PR does / why we need it**:
- Fix default setting of Kube API AWS ELB type from public to private
- Add new terraform module to create Kube API AWS NLB (Network LoadBalancer)
  - Currently using ELB (Classic LoadBalancer) which is previous generation
- Add new variable setting to enable using ELB/NLB type as Public or private
- Add setting guide
