### PR TITLE
Add to create efs when configuring infra

### DIFF
--- a/contrib/terraform/aws/modules/iam/main.tf
+++ b/contrib/terraform/aws/modules/iam/main.tf
@@ -69,6 +69,36 @@ resource "aws_iam_role_policy" "kube_control_plane" {
       "Resource": [
         "arn:aws:s3:::kubernetes-*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticfilesystem:DescribeAccessPoints",
+        "elasticfilesystem:DescribeFileSystems"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticfilesystem:CreateAccessPoint"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticfilesystem:DeleteAccessPoint",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
     }
   ]
 }
@@ -122,6 +152,36 @@ resource "aws_iam_role_policy" "kube-worker" {
             "ecr:BatchGetImage"
           ],
           "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "elasticfilesystem:DescribeAccessPoints",
+            "elasticfilesystem:DescribeFileSystems"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "elasticfilesystem:CreateAccessPoint"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/efs.csi.aws.com/cluster": "true"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "elasticfilesystem:DeleteAccessPoint",
+          "Resource": "*",
+          "Condition": {
+            "StringEquals": {
+              "aws:ResourceTag/efs.csi.aws.com/cluster": "true"
+            }
+          }
         }
       ]
 }

--- a/contrib/terraform/aws/templates/inventory.tpl
+++ b/contrib/terraform/aws/templates/inventory.tpl
@@ -26,3 +26,5 @@ kube_control_plane
 
 [k8s_cluster:vars]
 ${nlb_api_fqdn}
+${elb_api_fqdn}
+${aws_efs_filesystem}


### PR DESCRIPTION
- terraform을 이용하여 인프라를 구성할 때 efs 생성 및 설정 추가
- efs가 사용하는 security group에 모든 트래픽을 허용하는 inbound rule 추가, 별도로 지정하지 않으면 efs는 vpc의 default security group 사용
- terraform에서 생성되는 kubernetes-devtest-master와 kubernetes-devtest-node role에 efs policy 추가
- kubespray에서 사용할 수 있도록 생성 된 efs의 id를 담은 변수 추가

