### PR TITLE
Remove elb_api_fqdn from contrib/terraform/aws/templates/inventory.tpl

### DIFF
--- a/contrib/terraform/aws/templates/inventory.tpl
+++ b/contrib/terraform/aws/templates/inventory.tpl
@@ -26,5 +26,4 @@ kube_control_plane
 
 [k8s_cluster:vars]
 ${nlb_api_fqdn}
-${elb_api_fqdn}
 ${aws_efs_filesystem}


### PR DESCRIPTION
Remove `elb_api_fqdn` from `contrib/terraform/aws/templates/inventory.tpl`