### PR TITLE
Fix AZ hard coding + Add option to choose which subnets should be attached to Kube API NLB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ temp
 *.bak
 *.tfstate
 *.tfstate.backup
+*.terraform.lock.hcl
 .terraform/
 contrib/terraform/aws/credentials.tfvars
 /ssh-bastion.conf

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -42,14 +42,16 @@ module "aws-elb" {
 module "aws-nlb" {
   source = "./modules/nlb"
 
-  aws_cluster_name      = var.aws_cluster_name
-  aws_vpc_id            = module.aws-vpc.aws_vpc_id
-  aws_avail_zones       = slice(data.aws_availability_zones.available.names, 0, 3)
-  aws_subnet_ids_public = module.aws-vpc.aws_subnet_ids_public
-  aws_elb_api_internal  = var.aws_elb_api_internal
-  aws_elb_api_port      = var.aws_elb_api_port
-  k8s_secure_api_port   = var.k8s_secure_api_port
-  default_tags          = var.default_tags
+  aws_cluster_name          = var.aws_cluster_name
+  aws_vpc_id                = module.aws-vpc.aws_vpc_id
+  aws_avail_zones           = slice(data.aws_availability_zones.available.names, 0, 3)
+  aws_subnet_ids_public     = module.aws-vpc.aws_subnet_ids_public
+  aws_subnet_ids_private    = module.aws-vpc.aws_subnet_ids_private
+  aws_elb_api_internal      = var.aws_elb_api_internal
+  aws_elb_api_public_subnet = var.aws_elb_api_public_subnet
+  aws_elb_api_port          = var.aws_elb_api_port
+  k8s_secure_api_port       = var.k8s_secure_api_port
+  default_tags              = var.default_tags
 }
 
 module "aws-iam" {

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -20,7 +20,7 @@ module "aws-vpc" {
 
   aws_cluster_name         = var.aws_cluster_name
   aws_vpc_cidr_block       = var.aws_vpc_cidr_block
-  aws_avail_zones          = slice(data.aws_availability_zones.available.names, 0, 3)
+  aws_avail_zones          = data.aws_availability_zones.available.names
   aws_cidr_subnets_private = var.aws_cidr_subnets_private
   aws_cidr_subnets_public  = var.aws_cidr_subnets_public
   default_tags             = var.default_tags
@@ -31,7 +31,7 @@ module "aws-elb" {
 
   aws_cluster_name      = var.aws_cluster_name
   aws_vpc_id            = module.aws-vpc.aws_vpc_id
-  aws_avail_zones       = slice(data.aws_availability_zones.available.names, 0, 3)
+  aws_avail_zones       = data.aws_availability_zones.available.names
   aws_subnet_ids_public = module.aws-vpc.aws_subnet_ids_public
   aws_elb_api_internal  = var.aws_elb_api_internal
   aws_elb_api_port      = var.aws_elb_api_port
@@ -44,11 +44,9 @@ module "aws-nlb" {
 
   aws_cluster_name          = var.aws_cluster_name
   aws_vpc_id                = module.aws-vpc.aws_vpc_id
-  aws_avail_zones           = slice(data.aws_availability_zones.available.names, 0, 3)
-  aws_subnet_ids_public     = module.aws-vpc.aws_subnet_ids_public
-  aws_subnet_ids_private    = module.aws-vpc.aws_subnet_ids_private
+  aws_avail_zones           = data.aws_availability_zones.available.names
+  aws_elb_api_subnets       = var.aws_elb_api_public_subnet? module.aws-vpc.aws_subnet_ids_public : module.aws-vpc.aws_subnet_ids_private
   aws_elb_api_internal      = var.aws_elb_api_internal
-  aws_elb_api_public_subnet = var.aws_elb_api_public_subnet
   aws_elb_api_port          = var.aws_elb_api_port
   k8s_secure_api_port       = var.k8s_secure_api_port
   default_tags              = var.default_tags
@@ -70,7 +68,6 @@ resource "aws_instance" "bastion-server" {
   instance_type               = var.aws_bastion_size
   count                       = var.aws_bastion_num
   associate_public_ip_address = true
-  availability_zone           = element(slice(data.aws_availability_zones.available.names, 0, 3), count.index)
   subnet_id                   = element(module.aws-vpc.aws_subnet_ids_public, count.index)
 
   vpc_security_group_ids = module.aws-vpc.aws_security_group
@@ -95,7 +92,6 @@ resource "aws_instance" "k8s-master" {
 
   count = var.aws_kube_master_num
 
-  availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 3), count.index)
   source_dest_check     = var.aws_src_dest_check
   subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
@@ -129,7 +125,6 @@ resource "aws_instance" "k8s-etcd" {
 
   count = var.aws_etcd_num
 
-  availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 3), count.index)
   source_dest_check     = var.aws_src_dest_check
   subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 
@@ -150,7 +145,6 @@ resource "aws_instance" "k8s-worker" {
 
   count = var.aws_kube_worker_num
 
-  availability_zone = element(slice(data.aws_availability_zones.available.names, 0, 3), count.index)
   source_dest_check     = var.aws_src_dest_check
   subnet_id         = element(module.aws-vpc.aws_subnet_ids_private, count.index)
 

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -251,6 +251,8 @@ resource "null_resource" "inventories" {
 module "transit_gateway" {
   source = "./modules/tgw"
 
+  count = var.vpn_connection_enable ? 1 : 0
+
   create_tgw       = var.vpn_connection_enable
   
   aws_cluster_name = var.aws_cluster_name
@@ -283,11 +285,11 @@ module "vpn_connection" {
   aws_cluster_name               = var.aws_cluster_name
 
   customer_gateway_ip_address    = var.customer_gateway_ip
-  transit_gateway_id             = module.transit_gateway.ec2_transit_gateway_id
+  transit_gateway_id             = module.transit_gateway[0].ec2_transit_gateway_id
 
   local_cidr                     = var.local_cidr
 
-  transit_gateway_route_table_id = module.transit_gateway.ec2_transit_gateway_route_table_id
+  transit_gateway_route_table_id = module.transit_gateway[0].ec2_transit_gateway_route_table_id
 
   default_tags = var.default_tags
 }
@@ -298,7 +300,7 @@ resource "aws_route" "this" {
   destination_cidr_block = var.local_cidr
 
   route_table_id         = element(module.aws-vpc.aws_route_table_private, count.index)
-  transit_gateway_id     = module.transit_gateway.ec2_transit_gateway_id
+  transit_gateway_id     = module.transit_gateway[0].ec2_transit_gateway_id
 }
 
 resource "aws_security_group_rule" "allow-local-ingress" {

--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -188,7 +188,7 @@ resource "aws_efs_backup_policy" "policy" {
 }
 
 resource "aws_efs_mount_target" "alpha" {
-  count = length(var.aws_cidr_subnets_public)
+  count = length(var.aws_cidr_subnets_public) > length(data.aws_availability_zones.available.names) ? length(data.aws_availability_zones.available.names) : length(var.aws_cidr_subnets_public)
 
   file_system_id = aws_efs_file_system.efs.id
   subnet_id = element(module.aws-vpc.aws_subnet_ids_public, count.index)

--- a/contrib/terraform/aws/modules/elb/main.tf
+++ b/contrib/terraform/aws/modules/elb/main.tf
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "aws-allow-api-egress" {
 # Create a new AWS ELB for K8S API
 resource "aws_elb" "aws-elb-api" {
   name            = "kubernetes-elb-${var.aws_cluster_name}"
-  subnets         = var.aws_subnet_ids_public
+  subnets         = slice(var.aws_subnet_ids_public, 0, length(var.aws_avail_zones))
   security_groups = [aws_security_group.aws-elb.id]
 
   listener {

--- a/contrib/terraform/aws/modules/nlb/main.tf
+++ b/contrib/terraform/aws/modules/nlb/main.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "aws-nlb-api" {
   name               = "kubernetes-nlb-${var.aws_cluster_name}"
   load_balancer_type = "network"
   internal           = var.aws_elb_api_internal
-  subnets            = var.aws_subnet_ids_public
+  subnets            = var.aws_elb_api_public_subnet ? var.aws_subnet_ids_public : var.aws_subnet_ids_private
   idle_timeout       = 400
   enable_cross_zone_load_balancing   = true
 

--- a/contrib/terraform/aws/modules/nlb/main.tf
+++ b/contrib/terraform/aws/modules/nlb/main.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "aws-nlb-api" {
   name               = "kubernetes-nlb-${var.aws_cluster_name}"
   load_balancer_type = "network"
   internal           = var.aws_elb_api_internal
-  subnets            = var.aws_elb_api_public_subnet ? var.aws_subnet_ids_public : var.aws_subnet_ids_private
+  subnets            = length(var.aws_elb_api_subnets) <= length(var.aws_avail_zones) ? var.aws_elb_api_subnets : slice(var.aws_elb_api_subnets, 0, length(var.aws_avail_zones))
   idle_timeout       = 400
   enable_cross_zone_load_balancing   = true
 

--- a/contrib/terraform/aws/modules/nlb/variables.tf
+++ b/contrib/terraform/aws/modules/nlb/variables.tf
@@ -24,6 +24,11 @@ variable "aws_subnet_ids_public" {
   type        = list(string)
 }
 
+variable "aws_subnet_ids_private" {
+  description = "IDs of Private Subnets"
+  type        = list(string)
+}
+
 variable "default_tags" {
   description = "Tags for all resources"
   type        = map(string)
@@ -31,6 +36,12 @@ variable "default_tags" {
 
 variable "aws_elb_api_internal" {
   description   = "AWS ELB Scheme Internet-facing/Internal"
+  type          = bool
+  default	= true
+}
+
+variable "aws_elb_api_public_subnet" {
+  description   = "where to attach AWS ELB API endpoint (public/private subnet)"
   type          = bool
   default	= true
 }

--- a/contrib/terraform/aws/modules/nlb/variables.tf
+++ b/contrib/terraform/aws/modules/nlb/variables.tf
@@ -19,16 +19,6 @@ variable "aws_avail_zones" {
   type        = list(string)
 }
 
-variable "aws_subnet_ids_public" {
-  description = "IDs of Public Subnets"
-  type        = list(string)
-}
-
-variable "aws_subnet_ids_private" {
-  description = "IDs of Private Subnets"
-  type        = list(string)
-}
-
 variable "default_tags" {
   description = "Tags for all resources"
   type        = map(string)
@@ -44,4 +34,9 @@ variable "aws_elb_api_public_subnet" {
   description   = "where to attach AWS ELB API endpoint (public/private subnet)"
   type          = bool
   default	= true
+}
+
+variable "aws_elb_api_subnets" {
+  description   = "List of subnets to be attached to ELB API"
+  type          = list(string)
 }

--- a/contrib/terraform/aws/modules/vpc/main.tf
+++ b/contrib/terraform/aws/modules/vpc/main.tf
@@ -25,8 +25,8 @@ resource "aws_internet_gateway" "cluster-vpc-internetgw" {
 
 resource "aws_subnet" "cluster-vpc-subnets-public" {
   vpc_id            = aws_vpc.cluster-vpc.id
-  count             = length(var.aws_avail_zones)
-  availability_zone = element(var.aws_avail_zones, count.index)
+  count             = length(var.aws_cidr_subnets_public)
+  availability_zone = element(var.aws_avail_zones, count.index % length(var.aws_avail_zones))
   cidr_block        = element(var.aws_cidr_subnets_public, count.index)
 
   tags = merge(var.default_tags, tomap({
@@ -43,8 +43,8 @@ resource "aws_nat_gateway" "cluster-nat-gateway" {
 
 resource "aws_subnet" "cluster-vpc-subnets-private" {
   vpc_id            = aws_vpc.cluster-vpc.id
-  count             = length(var.aws_avail_zones)
-  availability_zone = element(var.aws_avail_zones, count.index)
+  count             = length(var.aws_cidr_subnets_private)
+  availability_zone = element(var.aws_avail_zones, count.index % length(var.aws_avail_zones))
   cidr_block        = element(var.aws_cidr_subnets_private, count.index)
 
   tags = merge(var.default_tags, tomap({

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -3,13 +3,12 @@ aws_cluster_name = "devtest"
 
 #VPC Vars
 aws_vpc_cidr_block       = "10.0.0.0/16"
-aws_cidr_subnets_private = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-aws_cidr_subnets_public = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+aws_cidr_subnets_public  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+aws_cidr_subnets_private = ["10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24"]
 
 #Bastion Host
 aws_bastion_num  = 1
 aws_bastion_size = "t2.medium"
-
 
 #Kubernetes Cluster
 aws_kube_master_num  = 3
@@ -23,7 +22,6 @@ aws_etcd_disk_size = 50
 aws_kube_worker_num  = 2
 aws_kube_worker_size = "t2.medium"
 aws_kube_worker_disk_size = 50
-
 
 #EC2 Source/Dest Check
 aws_src_dest_check      = false

--- a/contrib/terraform/aws/terraform.tfvars
+++ b/contrib/terraform/aws/terraform.tfvars
@@ -2,33 +2,37 @@
 aws_cluster_name = "devtest"
 
 #VPC Vars
-aws_vpc_cidr_block       = "10.250.192.0/18"
-aws_cidr_subnets_private = ["10.250.192.0/20", "10.250.208.0/20"]
-aws_cidr_subnets_public  = ["10.250.224.0/20", "10.250.240.0/20"]
+aws_vpc_cidr_block       = "10.0.0.0/16"
+aws_cidr_subnets_private = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+aws_cidr_subnets_public = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 
 #Bastion Host
+aws_bastion_num  = 1
 aws_bastion_size = "t2.medium"
 
 
 #Kubernetes Cluster
-
 aws_kube_master_num  = 3
 aws_kube_master_size = "t2.medium"
+aws_kube_master_disk_size = 50
 
-aws_etcd_num  = 3
+aws_etcd_num  = 0
 aws_etcd_size = "t2.medium"
+aws_etcd_disk_size = 50
 
-aws_kube_worker_num  = 4
+aws_kube_worker_num  = 2
 aws_kube_worker_size = "t2.medium"
+aws_kube_worker_disk_size = 50
+
 
 #EC2 Source/Dest Check
 aws_src_dest_check      = false
 
 #Settings AWS ELB
-
-aws_elb_api_port                = 6443
-k8s_secure_api_port             = 6443
-kube_insecure_apiserver_address = "0.0.0.0"
+aws_elb_api_port          = 6443
+k8s_secure_api_port       = 6443
+aws_elb_api_internal      = true
+aws_elb_api_public_subnet = true
 
 default_tags = {
   #  Env = "devtest"

--- a/contrib/terraform/aws/variables.tf
+++ b/contrib/terraform/aws/variables.tf
@@ -139,3 +139,9 @@ variable "aws_elb_api_internal" {
   type          = bool
   default	= true
 }
+
+variable "aws_elb_api_public_subnet" {
+  description   = "where to attach AWS ELB API endpoint (public/private subnet)"
+  type          = bool
+  default	= true
+}

--- a/docs/tmaxcloud/terraform_aws_elb.md
+++ b/docs/tmaxcloud/terraform_aws_elb.md
@@ -6,3 +6,11 @@
   ```
   `false` : Public  
   `true`  : Private  
+
+- Whether to create Kube API ELB attach to Private or Public subnets
+  file: contrib/terraform/aws/terraform.tfvars  
+  ```
+  aws_elb_api_public_subnet = true
+  ```
+  `false` : Attach Kube API ELB to Private subnets
+  `true`  : Attach Kube API ELB to Public subnets


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
Add option enable to choose which subnets should be used with KUBE API NLB
read  `docs/tmaxcloud/terraform_aws_elb.md` how to use
```
aws_elb_api_public_subnet = true
```

**What this PR does / why we need it**:
Add new variable enable user to choose which subnet should be used

**Which issue(s) this PR fixes**:
Fix hard coding always using public subnets to create Kube API NLB
Fix AZ hard coding - Error when number of AZ and Subnet are not the same
