### PR TITLE
Add option to choose which subnet (public/private) should be attached to ELB

### DIFF
--- a/contrib/terraform/aws/create-infrastructure.tf
+++ b/contrib/terraform/aws/create-infrastructure.tf
@@ -32,7 +32,7 @@ module "aws-elb" {
   aws_cluster_name      = var.aws_cluster_name
   aws_vpc_id            = module.aws-vpc.aws_vpc_id
   aws_avail_zones       = data.aws_availability_zones.available.names
-  aws_subnet_ids_public = module.aws-vpc.aws_subnet_ids_public
+  aws_elb_api_subnets   = var.aws_elb_api_public_subnet? module.aws-vpc.aws_subnet_ids_public : module.aws-vpc.aws_subnet_ids_private
   aws_elb_api_internal  = var.aws_elb_api_internal
   aws_elb_api_port      = var.aws_elb_api_port
   k8s_secure_api_port   = var.k8s_secure_api_port

--- a/contrib/terraform/aws/modules/elb/main.tf
+++ b/contrib/terraform/aws/modules/elb/main.tf
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "aws-allow-api-egress" {
 # Create a new AWS ELB for K8S API
 resource "aws_elb" "aws-elb-api" {
   name            = "kubernetes-elb-${var.aws_cluster_name}"
-  subnets         = slice(var.aws_subnet_ids_public, 0, length(var.aws_avail_zones))
+  subnets         = length(var.aws_elb_api_subnets) <= length(var.aws_avail_zones) ? var.aws_elb_api_subnets : slice(var.aws_elb_api_subnets, 0, length(var.aws_avail_zones))
   security_groups = [aws_security_group.aws-elb.id]
 
   listener {

--- a/contrib/terraform/aws/modules/elb/variables.tf
+++ b/contrib/terraform/aws/modules/elb/variables.tf
@@ -19,11 +19,6 @@ variable "aws_avail_zones" {
   type        = list(string)
 }
 
-variable "aws_subnet_ids_public" {
-  description = "IDs of Public Subnets"
-  type        = list(string)
-}
-
 variable "default_tags" {
   description = "Tags for all resources"
   type        = map(string)
@@ -33,4 +28,15 @@ variable "aws_elb_api_internal" {
   description   = "AWS ELB Scheme Internet-facing/Internal"
   type          = bool
   default	= true
+}
+
+variable "aws_elb_api_public_subnet" {
+  description   = "where to attach AWS ELB API endpoint (public/private subnet)"
+  type          = bool
+  default	= true
+}
+
+variable "aws_elb_api_subnets" {
+  description   = "List of subnets to be attached to ELB API"
+  type          = list(string)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
Add feature

**What this PR does / why we need it**:
Add option enable to choose which Subnet (public/private) should be attached to ELB

**Which issue(s) this PR fixes**:
Fix static subnets to be attached to ELB