### PR TITLE
[ims][274854] service account token 마운트 설정 추가

### DIFF
--- a/roles/kubernetes-apps/hypercloud/templates/01_init.yaml.j2
+++ b/roles/kubernetes-apps/hypercloud/templates/01_init.yaml.j2
@@ -47,6 +47,17 @@ metadata:
 
 ---
 
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hypercloud5-api-server-service-account-token
+  namespace: hypercloud5-system
+  annotations:
+    kubernetes.io/service-account.name: hypercloud5-admin
+type: kubernetes.io/service-account-token
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/roles/kubernetes-apps/hypercloud/templates/02_postgres-create.yaml.j2
+++ b/roles/kubernetes-apps/hypercloud/templates/02_postgres-create.yaml.j2
@@ -56,6 +56,9 @@ spec:
               subPath: postgres
             - mountPath: /docker-entrypoint-initdb.d
               name: initdbsql
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: hypercloud5-api-server-service-account-token
+              readOnly: true
       serviceAccountName: hypercloud5-admin    
       volumes:
       - name: data
@@ -67,6 +70,10 @@ spec:
           items:
           - key: INIT_DB_SQL
             path: init-db.sql
+      - name: hypercloud5-api-server-service-account-token
+        secret:
+          defaultMode: 420
+          secretName: hypercloud5-api-server-service-account-token
 ---
 
 kind: PersistentVolumeClaim

--- a/roles/kubernetes-apps/hypercloud/templates/03_hypercloud-api-server.yaml.j2
+++ b/roles/kubernetes-apps/hypercloud/templates/03_hypercloud-api-server.yaml.j2
@@ -103,6 +103,9 @@ spec:
           - name: html
             mountPath: /run/configs/html
             readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: hypercloud5-api-server-service-account-token
+            readOnly: true
       volumes:
       - name : html
         configMap:
@@ -130,6 +133,10 @@ spec:
           items:
           - key: ACCESS_TOKEN
             path: accessSecret
+      - name: hypercloud5-api-server-service-account-token
+        secret:
+          defaultMode: 420
+          secretName: hypercloud5-api-server-service-account-token
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
[ims][274854] service account token 마운트 설정 추가

(hypercloud5-api-server, postgres) deployment에 대해
service account token 시크릿 수동 생성 및 수동 마운트 추가