### PR TITLE
Add role to deploy storageclass for postgresql

### DIFF
--- a/docs/tmaxcloud/storageclass.md
+++ b/docs/tmaxcloud/storageclass.md
@@ -1,0 +1,17 @@
+# storageclass
+
+kubespray로 storageclass 설정 위해 inventory/tmaxcloud/group_vars/k8s_cluster/addons.yml에서 설정해야 하는 값은 다음과 같습니다.
+
+```yml
+postgresql_sc_name: postgresql을 배포하기 위해 필요한 pvc가 사용해야 하는 storageclass의 이름
+```
+
+### 예시
+
+예를 들어 아래와 같이 변수들의 값을 설정합니다.
+
+- nfs를 사용하는 환경에서는 무조건 `nfs`로 설정해야 합니다.
+
+```yml
+postgresql_sc_name: efs-sc-postgresql
+```

--- a/inventory/tmaxcloud/group_vars/k8s_cluster/addons.yml
+++ b/inventory/tmaxcloud/group_vars/k8s_cluster/addons.yml
@@ -8,6 +8,10 @@
 # This value can be 'nfs' or 'efs-sc' provided by the hypercloud, or any other value user create
 default_storageclass_name: nfs
 
+# StorageClass name required for pvc used by postgreSQL
+# If you are using nfs the value should be 'nfs'
+postgresql_sc_name: efs-sc-postgresql
+
 # nfs-external-provisioner
 nfs_external_provisioner_enabled: true
 nfs_namespace: nfs

--- a/roles/kubernetes-apps/meta/main.yml
+++ b/roles/kubernetes-apps/meta/main.yml
@@ -130,6 +130,12 @@ dependencies:
     tags:
       - default_storageclass
 
+  - role: kubernetes-apps/storageclass
+    when:
+      - aws_efs_csi_enabled
+    tags:
+      - storageclass
+
   - role: kubernetes-apps/ingress_controller/ingress_nginx
     when:
       - ingress_nginx_enabled

--- a/roles/kubernetes-apps/storageclass/defaults/main.yml
+++ b/roles/kubernetes-apps/storageclass/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for storageclass
+# postgresql_sc_name: efs-sc-postgresql

--- a/roles/kubernetes-apps/storageclass/tasks/main.yml
+++ b/roles/kubernetes-apps/storageclass/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# tasks file for storageclass
+- name: StorageClass | Generate Manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
+  with_items:
+    - { name: storageclass, file: aws-efs-storageclass-postgre.yml }
+  register: storageclass_manifests
+  when: inventory_hostname == groups['kube_control_plane'][0]
+
+- name: StorageClass | Apply Manifests
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
+    state: "latest"
+    wait: true
+  with_items:
+    - "{{ storageclass_manifests.results }}"
+  when:
+    - inventory_hostname == groups['kube_control_plane'][0]
+  loop_control:
+    label: "{{ item.item.file }}"

--- a/roles/kubernetes-apps/storageclass/templates/aws-efs-storageclass-postgre.yml.j2
+++ b/roles/kubernetes-apps/storageclass/templates/aws-efs-storageclass-postgre.yml.j2
@@ -1,0 +1,13 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ postgresql_sc_name }}
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: {{ aws_efs_filesystem_id }}
+  directoryPerms: "700"
+  uid: "999"
+  gid: "999"
+  basePath: "/dynamic_provisioning" # optional


### PR DESCRIPTION
- [이슈] aws 환경에서 efs를 사용하는 경우 postgreSQl이 정상적으로 배포되지 않음
  - 기존에는 default storageclass를 사용하는 pvc를 pod에 붙여 postgreSQL을 배포
  - default storageclass를 통해 생성되는 디렉토리의 권한은 700이고 소유자는 1000 부터 2000까지 순차적으로 부여
  - postgreSQL은 999 소유자가 필요, postgreSQL을 배포할 때 동적으로 소유자 변경이 불가
  
- [해결] 위 현상을 해결하기 위해 aws 환경에서 efs를 사용하는 경우 postgreSQL를 배포하기 위해 필요한 pvc가 사용해야 하는 storageclass를 배포하는 role 추가
  - `aws_efs_csi_enabled` tag가 true일 때 배포
  - 권한은 700이고 소유자는 999인 storageclass 추가
  - addons.yaml 파일에 `postgresql_sc_name` 변수 추가, nfs를 사용하는 환경에서는 `nfs`로 설정 필요
  - 해당 storageclass가 필요한 모듈들에서는 pvc spec에 `storageClassName: {{ postgresql_sc_name }}`를 추가 해야 함